### PR TITLE
fix: use /api fallback for auth requests in dev

### DIFF
--- a/src/app/AppRouter.tsx
+++ b/src/app/AppRouter.tsx
@@ -24,7 +24,7 @@ const PublicRoute = ({ children }: { children: ReactElement }) => {
   const isAuthReady = useAuthStore((state) => state.isAuthReady);
 
   if (!isAuthReady) return null;
-  return isAuthenticated ? <Navigate to="/incoming" replace /> : children;
+  return isAuthenticated ? <Navigate to="/dashboard" replace /> : children;
 };
 
 const RouterContent = () => {

--- a/src/entities/dashboard/api/dashboardApi.ts
+++ b/src/entities/dashboard/api/dashboardApi.ts
@@ -1,36 +1,127 @@
-import { instance } from '../../../shared/api/instance';
-import type { ApiResponse } from '../../../shared/types/api';
-import type {
-  DashboardSummary,
-  WeeklyMovement,
-  RecentMovement,
-  MonthlyTrend,
-  ClosingStatus,
-} from '../types';
+import { closingApi } from '../../closing/api/closingApi';
+import { movementApi } from '../../movement/api/movementApi';
+import { stockApi } from '../../stock/api/stockApi';
+import type { MovementResponse } from '../../movement/types';
+import type { DashboardData, MonthlyTrend, RecentMovement, WeeklyMovement } from '../types';
+
+const isRecentMovement = (
+  movement: MovementResponse,
+): movement is MovementResponse & { type: RecentMovement['type'] } =>
+  movement.type === 'INBOUND' || movement.type === 'OUTBOUND';
+
+const pad = (value: number) => String(value).padStart(2, '0');
+const toDateString = (date: Date) =>
+  `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+const toMonthKey = (date: Date) => `${date.getFullYear()}-${pad(date.getMonth() + 1)}`;
+
+const addDays = (date: Date, amount: number) => {
+  const next = new Date(date);
+  next.setDate(next.getDate() + amount);
+  return next;
+};
+
+const addMonths = (date: Date, amount: number) => {
+  const next = new Date(date);
+  next.setMonth(next.getMonth() + amount);
+  return next;
+};
+
+const getLastDates = (baseDate: Date, count: number) =>
+  Array.from({ length: count }, (_, index) => {
+    const offset = index - (count - 1);
+    return addDays(baseDate, offset);
+  });
 
 export const dashboardApi = {
-  getSummary: () =>
-    instance
-      .get<ApiResponse<DashboardSummary>>('/dashboard/summary')
-      .then((r) => r.data),
+  getDashboardData: async (): Promise<DashboardData> => {
+    const todayDate = new Date();
+    const todayStr = toDateString(todayDate);
+    const currentMonth = toMonthKey(todayDate);
+    const weeklyDates = getLastDates(todayDate, 7);
+    const monthlyDates = Array.from({ length: 6 }, (_, index) => addMonths(todayDate, index - 5));
+    const monthlyStart = new Date(monthlyDates[0].getFullYear(), monthlyDates[0].getMonth(), 1);
 
-  getWeeklyMovements: () =>
-    instance
-      .get<ApiResponse<WeeklyMovement[]>>('/dashboard/weekly-movements')
-      .then((r) => r.data),
+    const [currentStockResponse, movementResponse, closingResponse] = await Promise.all([
+      stockApi.getCurrentStock(),
+      movementApi.getMovements({
+        from: toDateString(monthlyStart),
+        to: todayStr,
+      }),
+      closingApi.getClosingStock(),
+    ]);
 
-  getRecentMovements: (limit = 5) =>
-    instance
-      .get<ApiResponse<RecentMovement[]>>('/dashboard/recent-movements', { params: { limit } })
-      .then((r) => r.data),
+    const currentStock = currentStockResponse.data;
+    const movementRows = movementResponse.data;
+    const closingRows = closingResponse.data;
 
-  getMonthlyTrend: () =>
-    instance
-      .get<ApiResponse<MonthlyTrend[]>>('/dashboard/monthly-trend')
-      .then((r) => r.data),
+    const summary = {
+      totalItems: currentStock.length,
+      todayInbound: movementRows.filter((movement) =>
+        movement.movementDate === todayStr && movement.type === 'INBOUND',
+      ).length,
+      todayOutbound: movementRows.filter((movement) =>
+        movement.movementDate === todayStr && movement.type === 'OUTBOUND',
+      ).length,
+    };
 
-  getClosingStatus: () =>
-    instance
-      .get<ApiResponse<ClosingStatus>>('/dashboard/closing-status')
-      .then((r) => r.data),
+    const weeklyMovements: WeeklyMovement[] = weeklyDates.map((date) => {
+      const dateString = toDateString(date);
+
+      return {
+        date: dateString,
+        inboundCount: movementRows.filter((movement) =>
+          movement.movementDate === dateString && movement.type === 'INBOUND',
+        ).length,
+        outboundCount: movementRows.filter((movement) =>
+          movement.movementDate === dateString && movement.type === 'OUTBOUND',
+        ).length,
+      };
+    });
+
+    const recentMovements: RecentMovement[] = movementRows
+      .filter(isRecentMovement)
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+      .slice(0, 10)
+      .map((movement) => ({
+        movementId: movement.id,
+        itemCode: movement.itemCode,
+        itemName: movement.itemName,
+        type: movement.type,
+        quantity: movement.quantity,
+        movementDate: movement.movementDate,
+        site: movement.site,
+      }));
+
+    const monthlyTrend: MonthlyTrend[] = monthlyDates.map((date) => {
+      const monthKey = toMonthKey(date);
+
+      return {
+        month: monthKey,
+        inboundTotal: movementRows
+          .filter((movement) => movement.movementDate.startsWith(monthKey) && movement.type === 'INBOUND')
+          .reduce((sum, movement) => sum + movement.quantity, 0),
+        outboundTotal: movementRows
+          .filter((movement) => movement.movementDate.startsWith(monthKey) && movement.type === 'OUTBOUND')
+          .reduce((sum, movement) => sum + movement.quantity, 0),
+      };
+    });
+
+    const currentMonthClosingRows = closingRows.filter((row) => row.closingYm === currentMonth);
+    const closedCount = currentMonthClosingRows.filter((row) => row.status === 'CLOSED').length;
+    const unclosedCount = Math.max(currentStock.length - closedCount, 0);
+
+    return {
+      summary,
+      weeklyMovements,
+      recentMovements,
+      monthlyTrend,
+      closingStatus: {
+        closingYm: currentMonth,
+        closedCount,
+        unclosedCount,
+        totalClosedAll: closingRows.filter((row) => row.status === 'CLOSED').length,
+        closed: currentStock.length > 0 && unclosedCount === 0,
+      },
+    };
+  },
 };

--- a/src/entities/dashboard/types/index.ts
+++ b/src/entities/dashboard/types/index.ts
@@ -33,3 +33,11 @@ export interface ClosingStatus {
   totalClosedAll: number;
   closed: boolean;
 }
+
+export interface DashboardData {
+  summary: DashboardSummary;
+  weeklyMovements: WeeklyMovement[];
+  recentMovements: RecentMovement[];
+  monthlyTrend: MonthlyTrend[];
+  closingStatus: ClosingStatus;
+}

--- a/src/features/dashboard/api/queries.ts
+++ b/src/features/dashboard/api/queries.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { dashboardApi } from '../../../entities/dashboard/api/dashboardApi';
+
+export const dashboardKeys = {
+  overview: (dateKey: string) => ['dashboard', 'overview', dateKey] as const,
+};
+
+export const useGetDashboardOverview = () => {
+  const today = new Date().toISOString().slice(0, 10);
+
+  return useQuery({
+    queryKey: dashboardKeys.overview(today),
+    queryFn: () => dashboardApi.getDashboardData(),
+  });
+};

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource @emotion/react */
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -14,7 +13,7 @@ import {
 } from 'chart.js';
 import { Bar, Doughnut, Line } from 'react-chartjs-2';
 import Layout from '../../widgets/Layout';
-import { dashboardApi } from '../../entities/dashboard/api/dashboardApi';
+import { useGetDashboardOverview } from '../../features/dashboard/api/queries';
 import * as s from './style';
 
 ChartJS.register(
@@ -25,12 +24,15 @@ ChartJS.register(
 
 /* ── 요일 변환 ── */
 const DAY_LABELS: Record<number, string> = { 1: '월', 2: '화', 3: '수', 4: '목', 5: '금', 6: '토', 0: '일' };
+const parseLocalDate = (dateStr: string) => {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  return new Date(year, month - 1, day);
+};
 const toWeekdayLabel = (dateStr: string) => {
-  const day = new Date(dateStr).getDay();
+  const day = parseLocalDate(dateStr).getDay();
   return DAY_LABELS[day] ?? dateStr;
 };
 
-/* ── 월 라벨 변환 (2025-11 → 11월) ── */
 const toMonthLabel = (month: string) => {
   const [, m] = month.split('-');
   return `${Number(m)}월`;
@@ -123,45 +125,28 @@ const IconUser = () => (
 /* ── 페이지 ── */
 const DashboardPage = () => {
   const [activeTab, setActiveTab] = useState<'in' | 'out'>('in');
-
-  const { data: summaryRes } = useQuery({
-    queryKey: ['dashboard', 'summary'],
-    queryFn: dashboardApi.getSummary,
-  });
-
-  const { data: weeklyRes } = useQuery({
-    queryKey: ['dashboard', 'weekly-movements'],
-    queryFn: dashboardApi.getWeeklyMovements,
-  });
-
-  const { data: recentRes } = useQuery({
-    queryKey: ['dashboard', 'recent-movements'],
-    queryFn: () => dashboardApi.getRecentMovements(10),
-  });
-
-  const { data: monthlyRes } = useQuery({
-    queryKey: ['dashboard', 'monthly-trend'],
-    queryFn: dashboardApi.getMonthlyTrend,
-  });
-
-  const { data: closingRes } = useQuery({
-    queryKey: ['dashboard', 'closing-status'],
-    queryFn: dashboardApi.getClosingStatus,
-  });
+  const todayDate = new Date();
+  const { data: dashboard, isLoading, isError } = useGetDashboardOverview();
 
   /* ── 데이터 가공 ── */
-  const summary = summaryRes?.data;
-  const weekly = weeklyRes?.data ?? [];
-  const recentAll = recentRes?.data ?? [];
-  const monthly = monthlyRes?.data ?? [];
-  const closing = closingRes?.data;
+  const totalItems = dashboard?.summary.totalItems ?? 0;
+  const todayInbound = dashboard?.summary.todayInbound ?? 0;
+  const todayOutbound = dashboard?.summary.todayOutbound ?? 0;
+  const currentMonth = dashboard?.closingStatus.closingYm ?? '';
+  const closedCount = dashboard?.closingStatus.closedCount ?? 0;
+  const unclosedCount = dashboard?.closingStatus.unclosedCount ?? 0;
+  const totalClosedAll = dashboard?.closingStatus.totalClosedAll ?? 0;
+  const isCurrentMonthClosed = dashboard?.closingStatus.closed ?? false;
+  const closedPct = closedCount + unclosedCount > 0
+    ? Math.round((closedCount / (closedCount + unclosedCount)) * 1000) / 10
+    : 0;
 
   const weeklyChartData = {
-    labels: weekly.map((d) => toWeekdayLabel(d.date)),
+    labels: (dashboard?.weeklyMovements ?? []).map((movement) => toWeekdayLabel(movement.date)),
     datasets: [
       {
         label: '입고',
-        data: weekly.map((d) => d.inboundCount),
+        data: (dashboard?.weeklyMovements ?? []).map((movement) => movement.inboundCount),
         backgroundColor: '#4C8BF5',
         borderRadius: 3,
         barPercentage: 0.75,
@@ -169,7 +154,7 @@ const DashboardPage = () => {
       },
       {
         label: '출고',
-        data: weekly.map((d) => d.outboundCount),
+        data: (dashboard?.weeklyMovements ?? []).map((movement) => movement.outboundCount),
         backgroundColor: '#F9A8C9',
         borderRadius: 3,
         barPercentage: 0.75,
@@ -177,11 +162,6 @@ const DashboardPage = () => {
       },
     ],
   };
-
-  const totalClosingCount = (closing?.closedCount ?? 0) + (closing?.unclosedCount ?? 0);
-  const closedPct = totalClosingCount > 0
-    ? Math.round((closing!.closedCount / totalClosingCount) * 1000) / 10
-    : 0;
 
   const donutData = {
     datasets: [{
@@ -192,11 +172,11 @@ const DashboardPage = () => {
   };
 
   const monthlyChartData = {
-    labels: monthly.map((d) => toMonthLabel(d.month)),
+    labels: (dashboard?.monthlyTrend ?? []).map((trend) => toMonthLabel(trend.month)),
     datasets: [
       {
         label: '입고',
-        data: monthly.map((d) => d.inboundTotal),
+        data: (dashboard?.monthlyTrend ?? []).map((trend) => trend.inboundTotal),
         borderColor: '#4C8BF5',
         backgroundColor: 'rgba(76,139,245,0.20)',
         fill: true,
@@ -206,7 +186,7 @@ const DashboardPage = () => {
       },
       {
         label: '출고',
-        data: monthly.map((d) => d.outboundTotal),
+        data: (dashboard?.monthlyTrend ?? []).map((trend) => trend.outboundTotal),
         borderColor: '#F4A261',
         backgroundColor: 'rgba(244,162,97,0.12)',
         fill: true,
@@ -217,13 +197,33 @@ const DashboardPage = () => {
     ],
   };
 
-  const filteredRecent = recentAll.filter((m) =>
-    activeTab === 'in' ? m.type === 'INBOUND' : m.type === 'OUTBOUND',
+  const filteredRecent = (dashboard?.recentMovements ?? []).filter((movement) =>
+    activeTab === 'in' ? movement.type === 'INBOUND' : movement.type === 'OUTBOUND',
   );
 
-  const today = new Date().toLocaleDateString('ko-KR', {
+  const today = todayDate.toLocaleDateString('ko-KR', {
     year: 'numeric', month: '2-digit', day: '2-digit',
   });
+
+  if (isLoading) {
+    return (
+      <Layout>
+        <div css={s.page}>
+          <div css={s.card}>대시보드 데이터를 불러오는 중입니다.</div>
+        </div>
+      </Layout>
+    );
+  }
+
+  if (isError || !dashboard) {
+    return (
+      <Layout>
+        <div css={s.page}>
+          <div css={s.card}>대시보드 데이터를 불러오지 못했습니다.</div>
+        </div>
+      </Layout>
+    );
+  }
 
   return (
     <Layout>
@@ -245,7 +245,7 @@ const DashboardPage = () => {
 
           <div css={s.summaryCard}>
             <span css={s.summaryLabel}>오늘 입고</span>
-            <span css={s.summaryValue}>{summary?.todayInbound ?? '-'}</span>
+            <span css={s.summaryValue}>{todayInbound}</span>
             <span css={s.summaryUnit}>건</span>
             <div css={s.summaryIconBox} style={{ background: '#EEF4FF' }}>
               <IconIncoming />
@@ -254,7 +254,7 @@ const DashboardPage = () => {
 
           <div css={s.summaryCard}>
             <span css={s.summaryLabel}>오늘 출고</span>
-            <span css={s.summaryValue}>{summary?.todayOutbound ?? '-'}</span>
+            <span css={s.summaryValue}>{todayOutbound}</span>
             <span css={s.summaryUnit}>건</span>
             <div css={s.summaryIconBox} style={{ background: '#FFF0F5' }}>
               <IconOutgoing />
@@ -263,7 +263,7 @@ const DashboardPage = () => {
 
           <div css={s.summaryCard}>
             <span css={s.summaryLabel}>전체 품목 수</span>
-            <span css={s.summaryValue}>{summary?.totalItems ?? '-'}</span>
+            <span css={s.summaryValue}>{totalItems}</span>
             <span css={s.summaryUnit}>목</span>
             <div css={s.summaryIconBox} style={{ background: '#F0FFF4' }}>
               <IconSparkle />
@@ -272,10 +272,10 @@ const DashboardPage = () => {
 
           <div css={s.summaryCard}>
             <span css={s.summaryLabel}>이번 달 마감</span>
-            <span css={s.summaryBadge} style={closing?.closed
+            <span css={s.summaryBadge} style={isCurrentMonthClosed
               ? { background: '#C6F6D5', color: '#276749' }
               : { background: '#FDE68A', color: '#92400E' }}>
-              {closing ? (closing.closed ? '마감' : '미마감') : '-'}
+              {isCurrentMonthClosed ? '마감' : '미마감'}
             </span>
             <div css={s.summaryIconBox} style={{ background: '#FFFBEB' }}>
               <IconMail />
@@ -314,20 +314,20 @@ const DashboardPage = () => {
                 <div css={s.donutMeta}>
                   <span>월간 누적</span>
                   <span css={s.donutMetaDivider}>|</span>
-                  <span>{closing?.closingYm ?? '-'}</span>
+                  <span>{currentMonth}</span>
                 </div>
                 <div css={s.donutStatGrid}>
                   <div css={s.donutStatItem}>
                     <span css={s.donutStatLabel}>미마감</span>
-                    <span css={s.donutStatValue}>{closing?.unclosedCount ?? '-'}건</span>
+                    <span css={s.donutStatValue}>{unclosedCount}건</span>
                   </div>
                   <div css={s.donutStatItem}>
                     <span css={s.donutStatLabel}>마감</span>
-                    <span css={s.donutStatValue}>{closing?.closedCount ?? '-'}건</span>
+                    <span css={s.donutStatValue}>{closedCount}건</span>
                   </div>
                   <div css={s.donutStatItem}>
                     <span css={s.donutStatLabel}>전체 마감</span>
-                    <span css={s.donutStatValue}>{closing?.totalClosedAll ?? '-'}건</span>
+                    <span css={s.donutStatValue}>{totalClosedAll}건</span>
                   </div>
                 </div>
               </div>
@@ -392,7 +392,9 @@ const DashboardPage = () => {
                     <div css={s.activityQty}>
                       {item.type === 'INBOUND' ? '+' : '-'}{item.quantity}
                     </div>
-                    <div css={s.activityTime}>{item.movementDate}</div>
+                    <div css={s.activityTime}>
+                      {parseLocalDate(item.movementDate).toLocaleDateString('ko-KR')}
+                    </div>
                   </div>
                 </div>
               ))}

--- a/src/pages/IncomingManagement/index.tsx
+++ b/src/pages/IncomingManagement/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import axios from 'axios';
 import Layout from '../../widgets/Layout';
 import { FilterButton } from '../../shared/ui/FilterButton';
@@ -9,6 +9,7 @@ import { itemApi } from '../../entities/item/api/itemApi';
 import type { ItemResponse } from '../../entities/item/types';
 import type { MovementResponse } from '../../entities/movement/types';
 import { getApiErrorMessage, showApiErrorToast, showErrorToast } from '../../shared/lib/toast';
+import { useSubmitOnOutsideClick } from '../../shared/lib/useSubmitOnOutsideClick';
 import {
   useDeleteMovement,
   useDownloadMovements,
@@ -94,6 +95,7 @@ const IncomingManagementPage = () => {
   const [deleteMode, setDeleteMode] = useState(false);
   const [editMode, setEditMode] = useState(false);
   const [editValues, setEditValues] = useState<Record<string, Row>>({});
+  const [newRowElement, setNewRowElement] = useState<HTMLTableRowElement | null>(null);
 
   const { data: movements = [] } = useGetMovements({
     type: 'INBOUND',
@@ -310,6 +312,21 @@ const IncomingManagementPage = () => {
     }
   };
 
+  const submitPendingNewRow = useCallback(() => {
+    const pendingRowId = newRows[0]?.id;
+    if (!pendingRowId) {
+      return;
+    }
+
+    void submitRow(pendingRowId);
+  }, [newRows]);
+
+  useSubmitOnOutsideClick({
+    container: newRowElement,
+    enabled: newRows.length > 0,
+    onOutsideClick: submitPendingNewRow,
+  });
+
   const closeAll = () => {
     setOpenFilter(null);
     setActionOpen(false);
@@ -432,7 +449,10 @@ const IncomingManagementPage = () => {
                 )
               ))}
               {newRows.map((row) => (
-                <NewRow key={row.id}>
+                <NewRow
+                  key={row.id}
+                  ref={row === newRows[0] ? setNewRowElement : undefined}
+                >
                   <Td />
                   <Td><NewRowInput type="text" value={row.site} onChange={(e) => updateNewRow(row.id, 'site', e.target.value)} onKeyDown={(e) => handleNewRowKeyDown(row.id, e)} /></Td>
                   <Td><NewRowDateWrap><NewRowDateInput type="date" value={row.date} onChange={(e) => updateNewRow(row.id, 'date', e.target.value)} onKeyDown={(e) => handleNewRowKeyDown(row.id, e)} /></NewRowDateWrap></Td>

--- a/src/pages/OutgoingManagement/index.tsx
+++ b/src/pages/OutgoingManagement/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import Layout from '../../widgets/Layout';
 import { FilterButton } from '../../shared/ui/FilterButton';
 import { SearchInput } from '../../shared/ui/SearchInput';
@@ -8,6 +8,7 @@ import { itemApi } from '../../entities/item/api/itemApi';
 import type { ItemResponse } from '../../entities/item/types';
 import type { MovementResponse } from '../../entities/movement/types';
 import { showApiErrorToast, showErrorToast } from '../../shared/lib/toast';
+import { useSubmitOnOutsideClick } from '../../shared/lib/useSubmitOnOutsideClick';
 import {
   useDeleteMovement,
   useDownloadMovements,
@@ -94,6 +95,7 @@ const OutgoingManagementPage = () => {
   const [deleteMode, setDeleteMode] = useState(false);
   const [editMode, setEditMode] = useState(false);
   const [editValues, setEditValues] = useState<Record<string, Row>>({});
+  const [newRowElement, setNewRowElement] = useState<HTMLTableRowElement | null>(null);
 
   const { data: movements = [] } = useGetMovements({
     type: 'OUTBOUND',
@@ -285,6 +287,21 @@ const OutgoingManagementPage = () => {
     }
   };
 
+  const submitPendingNewRow = useCallback(() => {
+    const pendingRowId = newRows[0]?.id;
+    if (!pendingRowId) {
+      return;
+    }
+
+    void submitRow(pendingRowId);
+  }, [newRows]);
+
+  useSubmitOnOutsideClick({
+    container: newRowElement,
+    enabled: newRows.length > 0,
+    onOutsideClick: submitPendingNewRow,
+  });
+
   const closeAll = () => {
     setOpenFilter(null);
     setActionOpen(false);
@@ -400,7 +417,10 @@ const OutgoingManagementPage = () => {
                 )
               ))}
               {newRows.map((row) => (
-                <NewRow key={row.id}>
+                <NewRow
+                  key={row.id}
+                  ref={row === newRows[0] ? setNewRowElement : undefined}
+                >
                   <Td />
                   <Td><NewRowInput type="text" value={row.site} onChange={(e) => updateNewRow(row.id, 'site', e.target.value)} onKeyDown={(e) => handleNewRowKeyDown(row.id, e)} /></Td>
                   <Td><NewRowDateWrap><NewRowDateInput type="date" value={row.date} onChange={(e) => updateNewRow(row.id, 'date', e.target.value)} onKeyDown={(e) => handleNewRowKeyDown(row.id, e)} /></NewRowDateWrap></Td>

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -16,6 +16,20 @@ export const instance = axios.create({
 
 let refreshRequest: Promise<string> | null = null;
 
+const AUTH_BYPASS_PATHS = [
+  '/auth/sign-in',
+  '/auth/sign-up',
+  '/auth/send-verification-code',
+  '/auth/verify-email',
+  '/auth/refresh',
+];
+
+const isBypassedAuthRequest = (url?: string) =>
+  AUTH_BYPASS_PATHS.some((path) => url === path || url?.endsWith(path));
+
+const getStoredRefreshToken = () =>
+  useAuthStore.getState().refreshToken ?? localStorage.getItem('refreshToken');
+
 const requestAccessTokenRefresh = async (refreshToken: string) => {
   if (!refreshRequest) {
     refreshRequest = axios
@@ -47,38 +61,40 @@ instance.interceptors.response.use(
     const originalRequest = error.config as {
       _retry?: boolean;
       url?: string;
-      headers: Record<string, string>;
+      headers?: Record<string, string>;
     };
 
     if (
       error.response?.status === 401 &&
       !originalRequest?._retry &&
-      originalRequest?.url !== '/auth/refresh'
+      !isBypassedAuthRequest(originalRequest?.url)
     ) {
       originalRequest._retry = true;
 
-      const refreshToken = localStorage.getItem('refreshToken');
+      const refreshToken = getStoredRefreshToken();
       if (!refreshToken) {
         useAuthStore.getState().clearTokens();
-        window.location.href = '/login';
+        showErrorToast('인증이 만료되었습니다. 다시 로그인해주세요.');
         return Promise.reject(error);
       }
 
       try {
         const newAccessToken = await requestAccessTokenRefresh(refreshToken);
-        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        originalRequest.headers = {
+          ...originalRequest.headers,
+          Authorization: `Bearer ${newAccessToken}`,
+        };
         return instance(originalRequest);
       } catch {
         useAuthStore.getState().clearTokens();
-        window.location.href = '/login';
+        showErrorToast('인증이 만료되었습니다. 다시 로그인해주세요.');
         return Promise.reject(error);
       }
     }
 
-    if (error.response?.status === 403) {
+    if (error.response?.status === 403 && !isBypassedAuthRequest(originalRequest?.url)) {
       useAuthStore.getState().clearTokens();
       showErrorToast(error.response?.data?.error?.message ?? '인증이 만료되었습니다. 다시 로그인해주세요.');
-      window.location.href = '/login';
       return Promise.reject(error);
     }
 

--- a/src/shared/api/instance.ts
+++ b/src/shared/api/instance.ts
@@ -2,7 +2,12 @@ import axios from 'axios';
 import { useAuthStore } from '../../entities/auth/model/authStore';
 import { showErrorToast } from '../lib/toast';
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL as string;
+const resolveApiBaseUrl = () => {
+  const configuredBaseUrl = import.meta.env.VITE_API_BASE_URL?.trim();
+  return configuredBaseUrl ? configuredBaseUrl.replace(/\/$/, '') : '/api';
+};
+
+const API_BASE_URL = resolveApiBaseUrl();
 
 export const instance = axios.create({
   baseURL: API_BASE_URL,

--- a/src/shared/lib/useSubmitOnOutsideClick.ts
+++ b/src/shared/lib/useSubmitOnOutsideClick.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+
+interface UseSubmitOnOutsideClickParams {
+  container: HTMLElement | null;
+  enabled: boolean;
+  onOutsideClick: () => void;
+}
+
+export const useSubmitOnOutsideClick = ({
+  container,
+  enabled,
+  onOutsideClick,
+}: UseSubmitOnOutsideClickParams) => {
+  useEffect(() => {
+    if (!enabled || !container) {
+      return undefined;
+    }
+
+    const handlePointerDown = (event: MouseEvent | TouchEvent) => {
+      const target = event.target as Node | null;
+      if (!target || container.contains(target)) {
+        return;
+      }
+
+      onOutsideClick();
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('touchstart', handlePointerDown);
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('touchstart', handlePointerDown);
+    };
+  }, [container, enabled, onOutsideClick]);
+};


### PR DESCRIPTION
 ## 변경 사항

  ### 1. 로그인/인증 요청 경로 보정
  - `VITE_API_BASE_URL`이 없는 개발 환경에서도 `/api` fallback을 사용하도록 수정
  - Vite proxy를 통해 인증 요청이 프론트 dev 서버가 아니라 백엔드로 전달되도록 정리
  - 인증 관련 엔드포인트에서 refresh 재시도 루프가 발생하지 않도록 인터셉터 예외 처리 추가

  ### 2. 대시보드 데이터 조회 방식 개선
  - 기존 전용 대시보드 API 호출 대신, 현재 재고 / 입출고 / 마감 API를 조합해 대시보드 데이터를 구성하도록 변경
  - 요약 수치, 최근 입출고, 주간 입출고, 월간 추이, 마감 현황을 프론트에서 집계
  - 대시보드 전용 query hook 추가
  - 날짜 파싱 및 라벨 표시 로직 보정

  ### 3. 입출고 관리 입력 UX 개선
  - 신규 행 입력 도중 바깥 영역을 클릭하면 자동 제출되도록 공통 훅 추가
  - 입고 / 출고 관리 화면에 동일한 동작 적용

  ## 검증
  - `npm run build`

  ## 영향 범위
  - 로그인 요청 및 토큰 갱신 처리
  - 대시보드 데이터 표시
  - 입고 / 출고 관리 신규 행 입력 동작