### PR TITLE
feat: 마감 추가 기능 구현

### DIFF
--- a/src/entities/closing/types/index.ts
+++ b/src/entities/closing/types/index.ts
@@ -19,6 +19,7 @@ export interface ClosingStockResponse {
 
 export interface CloseMonthRequest {
   closingYm: string;
+  itemId: string;
 }
 
 export interface CloseMonthResponse {

--- a/src/pages/ClosingManagement/index.tsx
+++ b/src/pages/ClosingManagement/index.tsx
@@ -18,12 +18,16 @@ import {
   TableWrap, Table, HeaderRow, Th, DataRow, Td,
   StatusText, CloseBtn, CancelBtn,
   ToolbarRight, ToolbarCancelBtn, ToolbarSaveBtn,
+  ModalOverlay, ModalCard, ModalTitle, ModalFieldLabel, ModalMonthInput,
+  ModalActions, ModalCancelBtn, ModalConfirmBtn,
+  ModalSearchInput, ModalItemList, ModalItemRow, ModalItemCode, ModalItemName, ModalEmptyText,
 } from './style';
+import { useSearchItems } from '../../features/item/api/queries';
 
 type FilterType = 'date' | 'status' | null;
 type ClosingFilterStatus = 'ALL' | 'CLOSED' | 'CANCELLED';
 
-const CLOSING_ACTIONS = ['마감 수정'];
+const CLOSING_ACTIONS = ['마감 추가', '마감 수정'];
 
 const ClosingManagementPage = () => {
   const [openFilter, setOpenFilter] = useState<FilterType>(null);
@@ -36,6 +40,12 @@ const ClosingManagementPage = () => {
   const [selectedDetailId, setSelectedDetailId] = useState<string | null>(null);
   const [editMode, setEditMode] = useState(false);
   const [pendingStatus, setPendingStatus] = useState<Record<string, 'CLOSED' | 'CANCELLED'>>({});
+  const [addModalOpen, setAddModalOpen] = useState(false);
+  const [addMonth, setAddMonth] = useState('');
+  const [addSearch, setAddSearch] = useState('');
+  const [addSelectedItems, setAddSelectedItems] = useState<Set<string>>(new Set());
+
+  const { data: allItems = [] } = useSearchItems(addSearch);
 
   const { data: closingRows = [] } = useGetClosingStock({
     status: statusFilter === 'ALL' ? undefined : statusFilter,
@@ -91,12 +101,12 @@ const ClosingManagementPage = () => {
     });
   };
 
-  const toggleStatus = async (id: string, closingYmValue: string, isClosed: boolean) => {
+  const toggleStatus = async (id: string, closingYmValue: string, itemId: string, isClosed: boolean) => {
     try {
       if (isClosed) {
         await cancelClosingMutation.mutateAsync(id);
       } else {
-        await closeMonthMutation.mutateAsync({ closingYm: closingYmValue });
+        await closeMonthMutation.mutateAsync({ closingYm: closingYmValue, itemId });
       }
     } catch (error) {
       showApiErrorToast(error, isClosed ? '마감 취소에 실패했습니다.' : '마감 처리에 실패했습니다.');
@@ -136,19 +146,19 @@ const ClosingManagementPage = () => {
     }
 
     try {
-      const monthsToClose = new Set<string>();
+      const itemsToClose: { closingYm: string; itemId: string }[] = [];
       const itemsToCancel: string[] = [];
 
       for (const row of changes) {
         if (pendingStatus[row.closingId] === 'CLOSED') {
-          monthsToClose.add(row.closingYm);
+          itemsToClose.push({ closingYm: row.closingYm, itemId: row.itemId });
         } else {
           itemsToCancel.push(row.closingId);
         }
       }
 
       await Promise.all([
-        ...Array.from(monthsToClose).map((ym) => closeMonthMutation.mutateAsync({ closingYm: ym })),
+        ...itemsToClose.map(({ closingYm, itemId }) => closeMonthMutation.mutateAsync({ closingYm, itemId })),
         ...itemsToCancel.map((id) => cancelClosingMutation.mutateAsync(id)),
       ]);
 
@@ -159,8 +169,41 @@ const ClosingManagementPage = () => {
     }
   };
 
+  const closeAddModal = () => {
+    setAddModalOpen(false);
+    setAddMonth('');
+    setAddSearch('');
+    setAddSelectedItems(new Set());
+  };
+
+  const toggleAddItem = (itemId: string) => {
+    setAddSelectedItems((prev) => {
+      const next = new Set(prev);
+      if (next.has(itemId)) next.delete(itemId);
+      else next.add(itemId);
+      return next;
+    });
+  };
+
+  const handleAddClosing = async () => {
+    if (!addMonth || addSelectedItems.size === 0) return;
+    try {
+      await Promise.all(
+        Array.from(addSelectedItems).map((itemId) =>
+          closeMonthMutation.mutateAsync({ closingYm: addMonth, itemId }),
+        ),
+      );
+      closeAddModal();
+    } catch (error) {
+      showApiErrorToast(error, '마감 추가에 실패했습니다.');
+    }
+  };
+
   const handleActionItem = (item: string) => {
-    if (item === '마감 수정') {
+    if (item === '마감 추가') {
+      setAddModalOpen(true);
+      setActionOpen(false);
+    } else if (item === '마감 수정') {
       enterEditMode();
     }
   };
@@ -181,6 +224,52 @@ const ClosingManagementPage = () => {
 
   return (
     <Layout>
+      {addModalOpen && (
+        <ModalOverlay onClick={closeAddModal}>
+          <ModalCard onClick={(e) => e.stopPropagation()}>
+            <ModalTitle>마감 추가</ModalTitle>
+            <div>
+              <ModalFieldLabel>마감 연월</ModalFieldLabel>
+              <ModalMonthInput
+                type="month"
+                value={addMonth}
+                onChange={(e) => setAddMonth(e.target.value)}
+              />
+            </div>
+            <div>
+              <ModalFieldLabel>자재 선택</ModalFieldLabel>
+              <ModalSearchInput
+                placeholder="자재코드·자재명 검색"
+                value={addSearch}
+                onChange={(e) => setAddSearch(e.target.value)}
+              />
+              <ModalItemList>
+                {allItems.length === 0 ? (
+                  <ModalEmptyText>자재가 없습니다.</ModalEmptyText>
+                ) : (
+                  allItems.map((item) => (
+                    <ModalItemRow key={item.itemId} onClick={() => toggleAddItem(item.itemId)}>
+                      <Checkbox checked={addSelectedItems.has(item.itemId)} onChange={() => toggleAddItem(item.itemId)} />
+                      <ModalItemCode>{item.itemCode}</ModalItemCode>
+                      <ModalItemName>{item.itemName}</ModalItemName>
+                    </ModalItemRow>
+                  ))
+                )}
+              </ModalItemList>
+            </div>
+            <ModalActions>
+              <ModalCancelBtn type="button" onClick={closeAddModal}>취소</ModalCancelBtn>
+              <ModalConfirmBtn
+                type="button"
+                disabled={!addMonth || addSelectedItems.size === 0}
+                onClick={() => void handleAddClosing()}
+              >
+                추가{addSelectedItems.size > 0 ? ` (${addSelectedItems.size})` : ''}
+              </ModalConfirmBtn>
+            </ModalActions>
+          </ModalCard>
+        </ModalOverlay>
+      )}
       {(openFilter || actionOpen) && <Backdrop onClick={closeAll} />}
 
       <PageInner>
@@ -285,9 +374,9 @@ const ClosingManagementPage = () => {
                             )
                           ) : (
                             isClosed ? (
-                              <CancelBtn type="button" onClick={() => void toggleStatus(row.closingId, row.closingYm, true)}>취소</CancelBtn>
+                              <CancelBtn type="button" onClick={() => void toggleStatus(row.closingId, row.closingYm, row.itemId, true)}>취소</CancelBtn>
                             ) : (
-                              <CloseBtn type="button" onClick={() => void toggleStatus(row.closingId, row.closingYm, false)}>마감</CloseBtn>
+                              <CloseBtn type="button" onClick={() => void toggleStatus(row.closingId, row.closingYm, row.itemId, false)}>마감</CloseBtn>
                             )
                           )}
                         </Td>

--- a/src/pages/ClosingManagement/style.ts
+++ b/src/pages/ClosingManagement/style.ts
@@ -439,3 +439,194 @@ export const DateRangeInput = styled.input`${dateRangeInput}`;
 export const DateRangeSep = styled.span`${dateRangeSep}`;
 export const CloseBtn = styled.button`${closeBtn}`;
 export const CancelBtn = styled.button`${cancelBtn}`;
+
+export const modalOverlay = css`
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const modalCard = css`
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 28px 32px;
+  width: 540px;
+  max-width: calc(100vw - 32px);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;
+
+export const modalTitle = css`
+  font-family: 'Pretendard Variable', sans-serif;
+  font-size: 18px;
+  font-weight: 700;
+  color: #1a1b1e;
+  margin: 0;
+  font-feature-settings: 'ss05' 1;
+`;
+
+export const modalFieldLabel = css`
+  font-family: 'Pretendard Variable', sans-serif;
+  font-size: 14px;
+  color: #595b66;
+  margin: 0 0 6px 0;
+  font-feature-settings: 'ss05' 1;
+`;
+
+export const modalMonthInput = css`
+  width: 100%;
+  height: 40px;
+  border: 1.5px solid #d1d3db;
+  border-radius: 8px;
+  padding: 0 12px;
+  font-family: 'Pretendard Variable', sans-serif;
+  font-size: 15px;
+  color: #1a1b1e;
+  outline: none;
+  box-sizing: border-box;
+  background: transparent;
+  cursor: pointer;
+  &:focus {
+    border-color: #0068e0;
+  }
+  &::-webkit-calendar-picker-indicator {
+    cursor: pointer;
+    opacity: 0.6;
+  }
+`;
+
+export const modalActions = css`
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+`;
+
+export const modalCancelBtn = css`
+  height: 38px;
+  padding: 0 18px;
+  background: #ffffff;
+  border: 1px solid #bbbcc2;
+  border-radius: 8px;
+  font-family: 'Pretendard Variable', sans-serif;
+  font-size: 15px;
+  font-weight: 500;
+  color: #595b66;
+  cursor: pointer;
+  &:hover {
+    background: #f5f6f8;
+  }
+`;
+
+export const modalConfirmBtn = css`
+  height: 38px;
+  padding: 0 20px;
+  background: #0068e0;
+  border: none;
+  border-radius: 8px;
+  font-family: 'Pretendard Variable', sans-serif;
+  font-size: 15px;
+  font-weight: 500;
+  color: #ffffff;
+  cursor: pointer;
+  &:hover {
+    background: #0056b8;
+  }
+  &:disabled {
+    background: #bbbcc2;
+    cursor: not-allowed;
+  }
+`;
+
+export const modalSearchInput = css`
+  width: 100%;
+  height: 36px;
+  border: 1.5px solid #d1d3db;
+  border-radius: 8px;
+  padding: 0 12px;
+  font-family: 'Pretendard Variable', sans-serif;
+  font-size: 14px;
+  color: #1a1b1e;
+  outline: none;
+  box-sizing: border-box;
+  background: transparent;
+  margin-bottom: 8px;
+  &:focus {
+    border-color: #0068e0;
+  }
+  &::placeholder {
+    color: #9497a0;
+  }
+`;
+
+export const modalItemList = css`
+  max-height: 240px;
+  overflow-y: auto;
+  border: 1px solid #e5e6ea;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const modalItemRow = css`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  cursor: pointer;
+  border-bottom: 1px solid #f0f1f4;
+  &:last-child {
+    border-bottom: none;
+  }
+  &:hover {
+    background: #f5f6f8;
+  }
+`;
+
+export const modalItemCode = css`
+  font-family: 'Pretendard Variable', sans-serif;
+  font-size: 13px;
+  color: #595b66;
+  white-space: nowrap;
+  flex-shrink: 0;
+  font-feature-settings: 'ss05' 1;
+`;
+
+export const modalItemName = css`
+  font-family: 'Pretendard Variable', sans-serif;
+  font-size: 14px;
+  color: #1a1b1e;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-feature-settings: 'ss05' 1;
+`;
+
+export const modalEmptyText = css`
+  font-family: 'Pretendard Variable', sans-serif;
+  font-size: 14px;
+  color: #9497a0;
+  text-align: center;
+  padding: 24px 0;
+  font-feature-settings: 'ss05' 1;
+`;
+
+export const ModalOverlay = styled.div`${modalOverlay}`;
+export const ModalCard = styled.div`${modalCard}`;
+export const ModalTitle = styled.h2`${modalTitle}`;
+export const ModalFieldLabel = styled.p`${modalFieldLabel}`;
+export const ModalMonthInput = styled.input`${modalMonthInput}`;
+export const ModalActions = styled.div`${modalActions}`;
+export const ModalCancelBtn = styled.button`${modalCancelBtn}`;
+export const ModalConfirmBtn = styled.button`${modalConfirmBtn}`;
+export const ModalSearchInput = styled.input`${modalSearchInput}`;
+export const ModalItemList = styled.div`${modalItemList}`;
+export const ModalItemRow = styled.div`${modalItemRow}`;
+export const ModalItemCode = styled.span`${modalItemCode}`;
+export const ModalItemName = styled.span`${modalItemName}`;
+export const ModalEmptyText = styled.p`${modalEmptyText}`;


### PR DESCRIPTION
## Summary
- 마감 추가 모달 구현: 자재 검색 + 체크박스 선택 + 마감 연월 선택
- `CloseMonthRequest`에 `itemId` 필드 추가 (API 스펙 반영)
- 선택된 자재별 `POST /closing` 병렬 호출
- 기존 마감 처리/일괄 수정 로직에도 `itemId` 전달 반영

## Test plan
- [ ] 마감 관리 페이지 → "마감 관리" 버튼 → "마감 추가" 클릭 시 모달 오픈
- [ ] 마감 연월 선택 및 자재 검색/체크박스 선택 동작 확인
- [ ] 추가 버튼 클릭 시 선택 자재 수만큼 마감 생성 확인
- [ ] 기존 행별 마감/취소 버튼 정상 동작 확인
- [ ] 마감 수정(편집 모드) 정상 동작 확인